### PR TITLE
HtmlAttrs v1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: .
   specs:
-    html_attrs (0.1.0)
+    html_attrs (1.1.0)
       actionview (>= 6.0)
-      activesupport (>= 6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ bundle add html_attrs
 ```ruby
 html_attrs = {
   class: 'bg-primary-500', data: { controller: 'popover', action: 'click->popover#toggle' }
-}.as_html_attrs
+}
 
 html_attrs = html_attrs.smart_merge(
   class: 'border border-primary-500', data: { controller: 'slideover' }, href: '#'
@@ -28,6 +28,7 @@ html_attrs = html_attrs.smart_merge(
   data: { controller: 'popover slideover', action: 'click->popover#toggle' },
   href: '#'
 }
+# Note: #smart_merge returns an HtmlAttrs object which is a subclass of Hash, so you can use it just like a hash.
 ```
 
 You can use this in helpers that accept HTML attributes as a hash, e.g:
@@ -62,7 +63,35 @@ You can also use the `to_s` method to get the string representation of the HTML 
 </a>
 ```
 
+Merging is done recursively:
+ * Strings are merged by concatenating them with a space.
+ * Arrays are merged with simple concatenation.
+ * Hashes are merged recursively using the above rules.
+ * Everything else is merged normally, just like with `Hash#merge`.
 
+Super simple, but super powerful.
+
+If one hash that has a string key and the other has a symbol key or vice-versa, we'll convert everything to whatever the first hash has.
+
+## Configuring mergeable attributes
+
+By default, this gem merges `class`, `style` and `data` attributes recursively. Which should usually be more than enough. You can easily customize this by specifying `mergeable_attributes:` when calling `smart_merge`. e.g:
+```ruby
+HtmlAttrs.new(class: 'bg-primary-500', id: 'test', aria_label: 'Help')
+  .smart_merge(aria_label: 'Another', href: '/test', mergeable_attributes: [:aria_label])
+# => { class: 'bg-primary-500', id: 'test', aria_label: 'Help Another', href: '/test' }
+```
+
+You can also just set `mergeable_attributes: :all` to merge everything. Or you can just use `smart_merge_all` which merges everything by default.
+
+```ruby
+{ class: 'bg-primary-500', id: 'test', aria_label: 'Help' }
+  .smart_merge_all(class: 'text-red-500', aria_label: 'Another', href: '/test')
+# => { class: 'bg-primary-500 text-red-500', id: 'test', aria_label: 'Help Another', href: '/test' }
+```
+
+
+## Other ways to use
 Alternative, you can use the `HtmlAttrs` class directly, e.g:
 ```ruby
 HtmlAttrs.smart_merge(
@@ -81,9 +110,7 @@ html_attrs.smart_merge( id: 'test', class: 'border')
 # => { class: 'bg-primary-500 border', data: { controller: 'popover' }, id: 'test' }
 ```
 
-Under the hood, `HtmlAttrs` is a simple wrapper around `ActiveSupport::HashWithIndifferentAccess`, so you can use it just like any other hash. The only difference is `#smart_merge` and `to_s`.
-
-Merging is done recursively. Strings are merged by concatenating them with a space. Arrays are merged with simple concatenation. Hashes are merged recursively using the above rules. Everything else is merged normally, just like with `Hash#merge`. Super simple, but super powerful.
+Under the hood, `HtmlAttrs` is a simple wrapper around `Hash`, so you can use it just like any other hash. The only difference is `#smart_merge`, `#smart_merge_all` and `to_s`.
 
 <br/>
 
@@ -95,15 +122,6 @@ I am working on a super-powerful Rails UI library - components as well as templa
 <br/>
 <br/>
 <br/>
-
-## Configuring mergeable attributes
-
-By default, this gem merges `class`, `style` and `data` attributes recursively. Which should usually be more than enough. You can easily customize this by specifying `mergeable_attributes:` when calling `smart_merge`. e.g:
-```ruby
-HtmlAttrs.new(class: 'bg-primary-500', id: 'test', aria_label: 'Help')
-  .smart_merge(aria_label: 'Another', href: '/test', mergeable_attributes: [:aria_label])
-# => { class: 'bg-primary-500', id: 'test', aria_label: 'Help Another', href: '/test' }
-```
 
 ## Development
 

--- a/html_attrs.gemspec
+++ b/html_attrs.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'actionview', '>= 6.0'
-  spec.add_dependency 'activesupport', '>= 6.0'
 end

--- a/lib/html_attrs.rb
+++ b/lib/html_attrs.rb
@@ -43,8 +43,11 @@ class HtmlAttrs < Hash
     return target if other.nil?
 
     if target.is_a?(Hash) || other.is_a?(Hash)
-      raise 'Expected target to be a hash or nil' if !target.nil? && !target.is_a?(Hash)
-      raise 'Expected other to be a hash or nil' if !other.nil? && !other.is_a?(Hash)
+      raise 'Expected target to be a hash or nil' unless target.is_a?(Hash)
+      raise 'Expected other to be a hash or nil' unless other.is_a?(Hash)
+
+      other = other.dup
+      target = target.dup
 
       target.each do |key, value|
         other_type_of_key = key.is_a?(Symbol) ? key.to_s : key.to_sym
@@ -69,15 +72,15 @@ class HtmlAttrs < Hash
     end
 
     if target.is_a?(Array) || other.is_a?(Array)
-      raise 'Expected target to be an array or nil' if !target.nil? && !target.is_a?(Array)
-      raise 'Expected other to be an array or nil' if !other.nil? && !other.is_a?(Array)
+      raise 'Expected target to be an array or nil' unless target.is_a?(Array)
+      raise 'Expected other to be an array or nil' unless other.is_a?(Array)
 
-      return (other || []).concat(target || [])
+      return (other.dup || []).concat(target.dup || [])
     end
 
     if target.is_a?(String) || other.is_a?(String)
-      raise 'Expected target to be a string or nil' if !target.nil? && !target.is_a?(String)
-      raise 'Expected other to be a string or nil' if !other.nil? && !other.is_a?(String)
+      raise 'Expected target to be a string or nil' unless target.is_a?(String)
+      raise 'Expected other to be a string or nil' unless other.is_a?(String)
 
       return [other.presence, target.presence].compact.join(' ')
     end

--- a/lib/html_attrs.rb
+++ b/lib/html_attrs.rb
@@ -1,18 +1,24 @@
 # frozen_string_literal: true
 
 require 'action_view'
-# require 'active_support/core_ext/hash/indifferent_access'
 
-class HtmlAttrs
-  VERSION = '1.0.0'
+class HtmlAttrs < Hash
+  VERSION = '1.1.0'
   DEFAULT_MERGEABLE_ATTRIBUTES = %i[class style data].to_set
 
-  def initialize(hash)
-    @hash = hash
-  end
+  def initialize(constructor = nil)
+    if constructor.respond_to?(:to_hash)
+      super()
+      update(constructor)
 
-  def method_missing(*args, **kwargs, &block)
-    @hash.send(*args, **kwargs, &block)
+      hash = constructor.is_a?(Hash) ? constructor : constructor.to_hash
+      self.default = hash.default if hash.default
+      self.default_proc = hash.default_proc if hash.default_proc
+    elsif constructor.nil?
+      super()
+    else
+      super(constructor)
+    end
   end
 
   def smart_merge(target)
@@ -20,23 +26,19 @@ class HtmlAttrs
       mergeable_attributes = target.delete(:mergeable_attributes)
     end
     mergeable_attributes ||= DEFAULT_MERGEABLE_ATTRIBUTES
-    self.class.smart_merge(@hash, target, mergeable_attributes: mergeable_attributes).as_html_attrs
+    self.class.smart_merge(self, target, mergeable_attributes: mergeable_attributes)
   end
 
-  # def smart_merge(other)
-  #   mergeable_attributes = other.delete(:mergeable_attributes) if other.is_a?(Hash) && other.key?(:mergeable_attributes)
-  #   mergeable_attributes ||= DEFAULT_MERGEABLE_ATTRIBUTES
-  #   self.class.smart_merge(self, other, mergeable_attributes: mergeable_attributes)
-  # end
+  def smart_merge_all(target)
+    target[:mergeable_attributes] = :all if target.is_a?(Hash)
+    smart_merge(target)
+  end
 
   def to_s
-    self.class.attributes(nil && @hash)
+    self.class.attributes(self)
   end
 
   def self.smart_merge(other, target, mergeable_attributes: DEFAULT_MERGEABLE_ATTRIBUTES)
-    # other  = other.with_indifferent_access if other.is_a?(Hash) && !other.is_a?(HashWithIndifferentAccess)
-    # target = target.with_indifferent_access if target.is_a?(Hash) && !target.is_a?(HashWithIndifferentAccess)
-
     return other if target.nil?
     return target if other.nil?
 
@@ -55,14 +57,12 @@ class HtmlAttrs
                            nil
                          end
 
-        other[key] =
+        other[key_with_value || key] =
           if key_with_value && attribute_mergeable?(key, mergeable_attributes)
             smart_merge(other[key_with_value], value, mergeable_attributes: :all)
           else
             value
           end
-
-        other.delete(other_type_of_key)
       end
 
       return other
@@ -85,6 +85,10 @@ class HtmlAttrs
     target
   end
 
+  def self.smart_merge_all(other, target)
+    smart_merge(other, target, mergeable_attributes: :all)
+  end
+
   def self.attribute_mergeable?(attribute, mergeable_attributes)
     return true if mergeable_attributes == :all
 
@@ -103,5 +107,13 @@ end
 class Hash
   def as_html_attrs
     HtmlAttrs.new(self)
+  end
+
+  def smart_merge(target)
+    as_html_attrs.smart_merge(target)
+  end
+
+  def smart_merge_all(target)
+    as_html_attrs.smart_merge_all(target)
   end
 end

--- a/test/test_html_attrs.rb
+++ b/test/test_html_attrs.rb
@@ -204,4 +204,39 @@ class TestHtmlAttrs < Minitest::Test
 
     assert_equal expected, result
   end
+
+  def test_smart_merge_all
+    hash_a = {
+      class: 'a b',
+      style: 'color: red;',
+      data: { z: 'test', e: { f: 'test 5' } },
+      id: 'test',
+      unmergeable: { x: '1', y: 2, z: {} }
+    }
+
+    hash_b = {
+      class: 'c d',
+      style: 'color: blue;',
+      data: { z: 'test 2', e: { f: 'test 6' } },
+      id: 'test2',
+      unmergeable: { x: '2', y: 3, z: { a: 3 } },
+      z: { a: 1, b: {} }
+    }
+
+    result = HtmlAttrs.smart_merge_all(hash_a, hash_b)
+
+    expected = {
+      class: 'a b c d',
+      style: 'color: red; color: blue;',
+      data: { z: 'test test 2', e: { f: 'test 5 test 6' } },
+      id: 'test test2',
+      unmergeable: { x: '1 2', y: 3, z: { a: 3 } },
+      z: { a: 1, b: {} }
+    }
+
+    assert_equal expected, result
+
+    result = hash_a.smart_merge_all(hash_b)
+    assert_equal expected, result
+  end
 end

--- a/test/test_html_attrs.rb
+++ b/test/test_html_attrs.rb
@@ -33,7 +33,7 @@ class TestHtmlAttrs < Minitest::Test
       id: 'test2',
       unmergeable: { x: '2', y: 3, z: false },
       z: { a: 1, b: {} }
-    }.with_indifferent_access
+    }
 
     assert_equal expected, result
   end
@@ -65,7 +65,7 @@ class TestHtmlAttrs < Minitest::Test
       id: 'test test2',
       unmergeable: { x: '1 2', y: 3, z: { a: 3 } },
       z: { a: 1, b: {} }
-    }.with_indifferent_access
+    }
 
     assert_equal expected, result
   end
@@ -75,19 +75,19 @@ class TestHtmlAttrs < Minitest::Test
     assert_nil result, nil
 
     result = HtmlAttrs.smart_merge({ class: 'test' }, nil)
-    expected = { class: 'test' }.with_indifferent_access
+    expected = { class: 'test' }
     assert_equal expected, result
 
     result = HtmlAttrs.smart_merge(nil, { class: 'test' })
-    expected = { class: 'test' }.with_indifferent_access
+    expected = { class: 'test' }
     assert_equal expected, result
 
     result = HtmlAttrs.smart_merge({ id: 'test2' }, { class: 'test' })
-    expected = { id: 'test2', class: 'test' }.with_indifferent_access
+    expected = { id: 'test2', class: 'test' }
     assert_equal expected, result
 
     result = HtmlAttrs.smart_merge({ class: 'test3', id: 'test2' }, { class: 'test' })
-    expected = { class: 'test3 test', id: 'test2' }.with_indifferent_access
+    expected = { class: 'test3 test', id: 'test2' }
     assert_equal expected, result
   end
 
@@ -117,23 +117,23 @@ class TestHtmlAttrs < Minitest::Test
       id: 'test2',
       unmergeable: { x: '2', y: 3, z: false },
       z: { a: 1, b: {} }
-    }.with_indifferent_access
+    }
 
     assert result.is_a?(HtmlAttrs)
     assert_equal expected, result
 
     result = HtmlAttrs.new(hash_a).smart_merge(nil)
     assert result.is_a?(HtmlAttrs)
-    assert_equal hash_a.with_indifferent_access, result
+    assert_equal hash_a, result
 
     result = HtmlAttrs.new(nil).smart_merge(hash_b)
     assert result.is_a?(HtmlAttrs)
-    assert_equal hash_b.with_indifferent_access, result
+    assert_equal hash_b, result
   end
 
   def test_passing_kwargs
     result = HtmlAttrs.new(class: 'test', data: 'a', x: 3).smart_merge(class: 'test2', id: 'd3', x: 4)
-    expected = { class: 'test test2', data: 'a', x: 4, id: 'd3' }.with_indifferent_access
+    expected = { class: 'test test2', data: 'a', x: 4, id: 'd3' }
     assert_equal expected, result
   end
 
@@ -169,14 +169,14 @@ class TestHtmlAttrs < Minitest::Test
       id: 'test2',
       unmergeable: { x: '2', y: 3, z: false },
       z: { a: 1, b: {} }
-    }.with_indifferent_access
+    }
 
     assert result.is_a?(HtmlAttrs)
     assert_equal expected, result
 
     result = hash_a.as_html_attrs.smart_merge(nil)
     assert result.is_a?(HtmlAttrs)
-    assert_equal hash_a.with_indifferent_access, result
+    assert_equal hash_a, result
   end
 
   def test_smart_merge_with_indifferent_access
@@ -188,7 +188,8 @@ class TestHtmlAttrs < Minitest::Test
 
     hash_b = {
       data: { 'd': 'e f', e: 'i', y: 'b' },
-      'id' => 'test2'
+      'id' => 'test2',
+      'zop' => nil
     }
     hash_b['class'] = 'c d'
 
@@ -197,8 +198,9 @@ class TestHtmlAttrs < Minitest::Test
     expected = {
       class: 'a b c d',
       data: { d: 'x y e f', e: 'i i', z: 'a', y: 'b' },
-      id: 'test2'
-    }.with_indifferent_access
+      id: 'test2',
+      'zop' => nil
+    }
 
     assert_equal expected, result
   end


### PR DESCRIPTION
* Subclassing Hash instead of HashWithIndifferentAccess
* Introduce `#smart_merge_all` to merge everything.
* Add `Hash#smart_merge` and `Hash#smart_merge_all` which just calls `Hash#as_html_attrs#smart_merge` and `Hash#as_html_attrs#smart_merge_all` respectively