### PR TITLE
feature: extend smart_merge method for string class objects

### DIFF
--- a/lib/html_attrs.rb
+++ b/lib/html_attrs.rb
@@ -121,4 +121,10 @@ class Hash
   def smart_merge_all(target)
     as_html_attrs.smart_merge_all(target)
   end
+
+  class String
+    def smart_merge(target)
+      HtmlAttrs.smart_merge(self, target, mergeable_attributes: HtmlAttrs::DEFAULT_MERGEABLE_ATTRIBUTES)
+    end
+  end
 end

--- a/test/test_string.rb
+++ b/test/test_string.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestString < Minitest::Test
+  def test_smart_merge
+    string_a = 'This is the first string'
+    string_b = 'and the other one'
+    result = string_a.smart_merge(string_b)
+    expected = 'This is the first string and the other one'
+
+    assert_equal expected, result
+  end
+end


### PR DESCRIPTION
The purpose is to use HtmlAttrs for String.
The code use `[other.presence, target.presence].compact.join(' ')` is working very well. And so, when you want to reuse it, I think you can just use the HtmlAttrs class, calling it via a smart_merge method inside String Class.